### PR TITLE
Create an invalidation request

### DIFF
--- a/.github/workflows/deploy_website.yaml
+++ b/.github/workflows/deploy_website.yaml
@@ -41,3 +41,7 @@ jobs:
       - name: Upload artifacts
         run: |
           aws s3 sync ./build/ s3://mpc-framework-website --delete
+
+      - name: Create invalidation request
+        run: |
+          aws cloudfront create-invalidation --distribution-id E28QOB6OXT8C4X --paths "/*"


### PR DESCRIPTION
## What is this PR doing?
With this PR, an invalidation request is introduced to the Cloudfront distribution.
The next time a viewer requests a file, Cloudfront returns to the origin to fetch the latest version of the file, so we ensure new files are served immediately after deployment.

Also, the caching policy in Cloudfront was modified and is now set to the default policy optimized for S3:
[658327ea-f89d-4fab-a63d-7e88639e58f6](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html#managed-cache-caching-optimized)

## How can these changes be manually tested?
Upload updated versions of the files to S3, trigger an invalidation request using the AWS cli, and verify that you received the latest version in your browser (also check the X-Cache header in the dev console to ensure that caching works as expected).

## Does this PR resolve or contribute to any issues?
It's optimizing caching.

## Checklist

- [X] I have manually tested these changes
- [X] Post a link to the PR in the group chat

## Guidelines

- If your PR is not ready, mark it as a draft
